### PR TITLE
wordpress-fargate: update modules and providers

### DIFF
--- a/aws/wordpress_fargate/alb.tf
+++ b/aws/wordpress_fargate/alb.tf
@@ -3,7 +3,6 @@ module "acm_alb" {
   version     = "~> v3.0"
   domain_name = var.public_alb_domain
   zone_id     = data.aws_route53_zone.this.zone_id
-  tags        = var.tags
 }
 
 resource "aws_security_group" "alb" {
@@ -31,8 +30,6 @@ resource "aws_security_group" "alb" {
     protocol  = "-1"
     self      = true
   }
-
-  tags = var.tags
 }
 
 
@@ -59,5 +56,4 @@ module "alb" {
       backend_port     = 80
     }
   ]
-  tags = var.tags
 }

--- a/aws/wordpress_fargate/alb.tf
+++ b/aws/wordpress_fargate/alb.tf
@@ -1,6 +1,6 @@
 module "acm_alb" {
   source      = "terraform-aws-modules/acm/aws"
-  version     = "~> v2.0"
+  version     = "~> v3.0"
   domain_name = var.public_alb_domain
   zone_id     = data.aws_route53_zone.this.zone_id
   tags        = var.tags
@@ -38,7 +38,7 @@ resource "aws_security_group" "alb" {
 
 module "alb" {
   source             = "terraform-aws-modules/alb/aws"
-  version            = "~> 5.0"
+  version            = "~> 6.0"
   name               = "${var.prefix}-${var.environment}"
   load_balancer_type = "application"
   vpc_id             = module.vpc.vpc_id
@@ -47,7 +47,7 @@ module "alb" {
 
   https_listeners = [
     {
-      "certificate_arn" = module.acm_alb.this_acm_certificate_arn
+      "certificate_arn" = module.acm_alb.acm_certificate_arn
       "port"            = 443
     },
   ]

--- a/aws/wordpress_fargate/cloudfront.tf
+++ b/aws/wordpress_fargate/cloudfront.tf
@@ -5,7 +5,6 @@ module "acm" {
   version     = "~> v3.0"
   domain_name = var.site_domain
   zone_id     = data.aws_route53_zone.this.zone_id
-  tags        = var.tags
 
   providers = {
     aws = aws.us_east_1 # cloudfront needs acm certificate to be from "us-east-1" region
@@ -99,7 +98,6 @@ resource "aws_cloudfront_distribution" "this" {
     viewer_protocol_policy = "redirect-to-https"
   }
   price_class = var.cf_price_class
-  tags        = var.tags
   restrictions {
     geo_restriction {
       restriction_type = "none"

--- a/aws/wordpress_fargate/cloudfront.tf
+++ b/aws/wordpress_fargate/cloudfront.tf
@@ -2,7 +2,7 @@
 
 module "acm" {
   source      = "terraform-aws-modules/acm/aws"
-  version     = "~> v2.0"
+  version     = "~> v3.0"
   domain_name = var.site_domain
   zone_id     = data.aws_route53_zone.this.zone_id
   tags        = var.tags
@@ -108,7 +108,7 @@ resource "aws_cloudfront_distribution" "this" {
 
 
   viewer_certificate {
-    acm_certificate_arn      = module.acm.this_acm_certificate_arn
+    acm_certificate_arn      = module.acm.acm_certificate_arn
     ssl_support_method       = "sni-only"
     minimum_protocol_version = "TLSv1.1_2016"
   }

--- a/aws/wordpress_fargate/db.tf
+++ b/aws/wordpress_fargate/db.tf
@@ -23,13 +23,11 @@ resource "aws_rds_cluster" "this" {
     min_capacity             = var.db_min_capacity
   }
   final_snapshot_identifier = "${var.prefix}-${var.environment}-${random_string.snapshot_suffix.result}"
-  tags                      = var.tags
 }
 
 resource "aws_db_subnet_group" "this" {
   name       = "${var.prefix}-${var.environment}"
   subnet_ids = module.vpc.private_subnets
-  tags       = var.tags
 }
 
 resource "aws_security_group" "db" {
@@ -52,19 +50,16 @@ resource "aws_security_group" "db" {
   lifecycle {
     create_before_destroy = true
   }
-  tags = var.tags
 }
 
 resource "aws_ssm_parameter" "db_master_user" {
   name  = "/${var.prefix}/${var.environment}/db_master_user"
   type  = "SecureString"
   value = var.db_master_username
-  tags  = var.tags
 }
 
 resource "aws_ssm_parameter" "db_master_password" {
   name  = "/${var.prefix}/${var.environment}/db_master_password"
   type  = "SecureString"
   value = var.db_master_password
-  tags  = var.tags
 }

--- a/aws/wordpress_fargate/efs.tf
+++ b/aws/wordpress_fargate/efs.tf
@@ -1,6 +1,5 @@
 resource "aws_efs_file_system" "this" {
   creation_token = "${var.prefix}-${var.environment}"
-  tags           = var.tags
 }
 
 resource "aws_efs_mount_target" "this" {
@@ -30,5 +29,4 @@ resource "aws_security_group" "efs" {
     protocol  = "tcp"
     self      = true
   }
-  tags = var.tags
 }

--- a/aws/wordpress_fargate/fargate.tf
+++ b/aws/wordpress_fargate/fargate.tf
@@ -337,8 +337,8 @@ resource "aws_route53_record" "wordpress" {
   type    = "A"
 
   alias {
-    name                   = module.alb.this_lb_dns_name
-    zone_id                = module.alb.this_lb_zone_id
+    name                   = module.alb.lb_dns_name
+    zone_id                = module.alb.lb_zone_id
     evaluate_target_health = true
   }
 }

--- a/aws/wordpress_fargate/fargate.tf
+++ b/aws/wordpress_fargate/fargate.tf
@@ -1,7 +1,6 @@
 # Ref - https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_execution_IAM_role.html
 resource "aws_iam_role" "task_execution_role" {
   name = "${var.prefix}-task-execution-role-${var.environment}"
-  tags = var.tags
 
   assume_role_policy = <<EOF
 {
@@ -53,7 +52,6 @@ resource "aws_iam_role_policy_attachment" "task_execution_policy_attach" {
 
 resource "aws_iam_role" "task_role" {
   name = "${var.prefix}-task-role-${var.environment}"
-  tags = var.tags
 
   assume_role_policy = <<EOF
 {
@@ -119,8 +117,6 @@ resource "aws_security_group" "wordpress" {
     protocol        = "tcp"
     security_groups = [aws_security_group.alb.id, aws_security_group.efs.id]
   }
-
-  tags = var.tags
 }
 
 resource "aws_ecs_service" "this" {
@@ -215,7 +211,6 @@ CONTAINER_DEFINITION
 
 resource "aws_cloudwatch_log_group" "wordpress" {
   name              = "/${var.prefix}/${var.environment}/fg-task"
-  tags              = var.tags
   retention_in_days = var.log_retention_in_days
 }
 

--- a/aws/wordpress_fargate/provider.tf
+++ b/aws/wordpress_fargate/provider.tf
@@ -1,17 +1,31 @@
-provider "aws" {
-}
-
 terraform {
   backend "s3" {
     bucket = "mybucket"
     key    = "wordpress"
+  }
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.38"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "aws" {
+  default_tags {
+    tags = var.tags
   }
 }
 
 provider "aws" {
   alias   = "us_east_1"
   region  = "us-east-1"
-}
 
-provider "random" {
+  default_tags {
+    tags = var.tags
+  }
 }

--- a/aws/wordpress_fargate/vpc.tf
+++ b/aws/wordpress_fargate/vpc.tf
@@ -9,6 +9,6 @@ module "vpc" {
   single_nat_gateway     = false
   one_nat_gateway_per_az = false
   tags                   = var.tags
-  version                = "~>2.0"
+  version                = "~>3.0"
   enable_dns_hostnames   = true
 }

--- a/aws/wordpress_fargate/vpc.tf
+++ b/aws/wordpress_fargate/vpc.tf
@@ -8,7 +8,6 @@ module "vpc" {
   enable_nat_gateway     = true
   single_nat_gateway     = false
   one_nat_gateway_per_az = false
-  tags                   = var.tags
   version                = "~>3.0"
   enable_dns_hostnames   = true
 }


### PR DESCRIPTION
This pull request is one of several changes I made in the course of adapting the wordpress-fargate recipe to my own use.  I decided to break up the changes by topic area to make reviewing them more manageable.  This PR is the first of four.

This change is mostly housekeeping.  I've updated the terraform providers and modules to ensure that we use their latest major releases.  The module updates required some minor code changes, and I've set the minimum version for the aws provider to 3.38.0 in order to take advantage of the newly-introduced [default_tags](https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#3380-april-30-2021) feature, which defines a default set of tags for all AWS resources in one shot, rather than having to apply them to each resource individually.