### PR TITLE
wordpress-fargate: update Aurora to mysql 5.7

### DIFF
--- a/aws/wordpress_fargate/db.tf
+++ b/aws/wordpress_fargate/db.tf
@@ -5,7 +5,7 @@ resource "random_string" "snapshot_suffix" {
 
 resource "aws_rds_cluster" "this" {
   cluster_identifier      = "${var.prefix}-${var.environment}"
-  engine                  = "aurora"
+  engine                  = "aurora-mysql"
   engine_mode             = "serverless"
   vpc_security_group_ids  = [aws_security_group.db.id]
   db_subnet_group_name    = aws_db_subnet_group.this.name

--- a/aws/wordpress_fargate/db.tf
+++ b/aws/wordpress_fargate/db.tf
@@ -10,7 +10,7 @@ resource "aws_rds_cluster" "this" {
   vpc_security_group_ids  = [aws_security_group.db.id]
   db_subnet_group_name    = aws_db_subnet_group.this.name
   engine_version          = var.db_engine_version
-  availability_zones      = data.aws_availability_zones.this.names
+  availability_zones      = slice(data.aws_availability_zones.this.names, 0, 3)
   database_name           = "wordpress"
   master_username         = var.db_master_username
   master_password         = var.db_master_password

--- a/aws/wordpress_fargate/variables.tf
+++ b/aws/wordpress_fargate/variables.tf
@@ -79,7 +79,7 @@ variable "db_master_password" {
 }
 variable "db_engine_version" {
   description = "The database engine version"
-  default     = "5.6.10a"
+  default     = "5.7.mysql_aurora.2.07.1"
 }
 variable "db_auto_pause" {
   description = "Whether to enable auto pause"


### PR DESCRIPTION
In this change, I'm kicking the Aurora cluster's engine over to mysql 5.7.  I also discovered during testing that cluster creation errors out if the AWS region has more than three availability zones, so I adjusted it to only use the first three (which is also where the rest of the infrastructure is created, assuming the default number of subnets are in use).