### PR TITLE
wordpress-fargate: lock down security group permissions

### DIFF
--- a/aws/wordpress_fargate/alb.tf
+++ b/aws/wordpress_fargate/alb.tf
@@ -25,13 +25,6 @@ resource "aws_security_group" "alb" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  ingress {
-    from_port = 0
-    to_port   = 0
-    protocol  = "-1"
-    self      = true
-  }
-
   tags = var.tags
 }
 

--- a/aws/wordpress_fargate/db.tf
+++ b/aws/wordpress_fargate/db.tf
@@ -27,19 +27,20 @@ resource "aws_rds_cluster" "this" {
 }
 
 resource "aws_db_subnet_group" "this" {
-  name       = "${var.prefix}-${var.environment}"
-  subnet_ids = module.vpc.private_subnets
-  tags       = var.tags
+  name        = "${var.prefix}-${var.environment}"
+  description = "database security group"
+  subnet_ids  = module.vpc.private_subnets
+  tags        = var.tags
 }
 
 resource "aws_security_group" "db" {
   vpc_id = module.vpc.vpc_id
   name   = "${var.prefix}-db-${var.environment}"
   ingress {
-    protocol  = "tcp"
-    from_port = 3306
-    to_port   = 3306
-    self      = true
+    protocol        = "tcp"
+    from_port       = 3306
+    to_port         = 3306
+    security_groups = [aws_security_group.wordpress.id]
   }
 
   egress {

--- a/aws/wordpress_fargate/efs.tf
+++ b/aws/wordpress_fargate/efs.tf
@@ -14,7 +14,7 @@ resource "aws_efs_mount_target" "this" {
 
 resource "aws_security_group" "efs" {
   name        = "${var.prefix}-efs-${var.environment}"
-  description = "Allow traffic ffrom self"
+  description = "EFS security group"
   vpc_id      = module.vpc.vpc_id
 
   egress {
@@ -25,10 +25,10 @@ resource "aws_security_group" "efs" {
   }
 
   ingress {
-    from_port = 2049
-    to_port   = 2049
-    protocol  = "tcp"
-    self      = true
+    from_port       = 2049
+    to_port         = 2049
+    protocol        = "tcp"
+    security_groups = [aws_security_group.wordpress.id]
   }
   tags = var.tags
 }

--- a/aws/wordpress_fargate/fargate.tf
+++ b/aws/wordpress_fargate/fargate.tf
@@ -114,10 +114,10 @@ resource "aws_security_group" "wordpress" {
   }
 
   ingress {
-    from_port       = 0
-    to_port         = 0
+    from_port       = 80
+    to_port         = 80
     protocol        = "tcp"
-    security_groups = [aws_security_group.alb.id, aws_security_group.efs.id]
+    security_groups = [aws_security_group.alb.id]
   }
 
   tags = var.tags
@@ -131,7 +131,7 @@ resource "aws_ecs_service" "this" {
   launch_type      = "FARGATE"
   platform_version = "1.4.0" // required for mounting efs
   network_configuration {
-    security_groups = [aws_security_group.alb.id, aws_security_group.db.id, aws_security_group.efs.id]
+    security_groups = [aws_security_group.wordpress.id]
     subnets         = module.vpc.private_subnets
   }
 


### PR DESCRIPTION
This change tightens down all the security group definitions.  The wordpress security group previously went unused.  I've now assigned it to the ecs cluster and reworked the security group rules to correctly model all expected traffic flows.  The new logic describes traffic as being allowed between two security groups when one resource needs to communicate with another, instead of assigning every security group to the ecs cluster so that both sides of a connection reside within the same group.  I also modified several rules which previously allowed incoming connections on all ports to restrict them to only ports that our intended services are listening on.