### PR TITLE
wordpress-fargate: modernize encryption settings

### DIFF
--- a/aws/wordpress_fargate/alb.tf
+++ b/aws/wordpress_fargate/alb.tf
@@ -49,6 +49,7 @@ module "alb" {
     {
       "certificate_arn" = module.acm_alb.this_acm_certificate_arn
       "port"            = 443
+      "ssl_policy"      = "ELBSecurityPolicy-FS-1-2-Res-2020-10"
     },
   ]
 

--- a/aws/wordpress_fargate/cloudfront.tf
+++ b/aws/wordpress_fargate/cloudfront.tf
@@ -21,7 +21,7 @@ resource "aws_cloudfront_distribution" "this" {
       http_port              = 80
       https_port             = 443
       origin_protocol_policy = "https-only"
-      origin_ssl_protocols   = ["TLSv1", "TLSv1.1", "TLSv1.2"]
+      origin_ssl_protocols   = ["TLSv1.2"]
     }
   }
 
@@ -110,7 +110,7 @@ resource "aws_cloudfront_distribution" "this" {
   viewer_certificate {
     acm_certificate_arn      = module.acm.this_acm_certificate_arn
     ssl_support_method       = "sni-only"
-    minimum_protocol_version = "TLSv1.1_2016"
+    minimum_protocol_version = "TLSv1.2_2019"
   }
 
   # By default, cloudfront caches error for five minutes. There can be situation when a developer has accidentally broken the website and you would not want to wait for five minutes for the error response to be cached.

--- a/aws/wordpress_fargate/efs.tf
+++ b/aws/wordpress_fargate/efs.tf
@@ -1,5 +1,6 @@
 resource "aws_efs_file_system" "this" {
   creation_token = "${var.prefix}-${var.environment}"
+  encrypted      = true
   tags           = var.tags
 }
 


### PR DESCRIPTION
This pull request consists of two changes: encrypting EFS's file storage, and restricting the TLS settings to only use modern ciphers.  Web browsers have already started disabling earlier TLS versions; at this point allowing older ciphers just increases attack surface without meaningfully improving compatibility with existing web clients, and I'd rather see settings that are secure by default.

I'm open to adding variables to configure TLS settings rather than hardcoding them in cloudfront.tf and alb.tf, if that would be a preferred approach.