### PR TITLE
Fix Terraform type constraints and provider syntax for AWS modules (#29)

### DIFF
--- a/aws/aws_domain_redirect/variables.tf
+++ b/aws/aws_domain_redirect/variables.tf
@@ -43,6 +43,6 @@ variable "lambda_logging_enabled" {
 
 variable "tags" {
   description = "AWS Tags to add to all resources created (where possible); see https://aws.amazon.com/answers/account-management/aws-tagging-strategies/"
-  type        = "map"
+  type        = map(string)
   default     = {}
 }

--- a/aws/aws_ec2_ebs_docker_host/variables.tf
+++ b/aws/aws_ec2_ebs_docker_host/variables.tf
@@ -97,6 +97,6 @@ variable "allow_incoming_dns" {
 
 variable "tags" {
   description = "AWS Tags to add to all resources created (where possible); see https://aws.amazon.com/answers/account-management/aws-tagging-strategies/"
-  type        = "map"
+  type        = map(string)
   default     = {}
 }

--- a/aws/aws_lambda_api/variables.tf
+++ b/aws/aws_lambda_api/variables.tf
@@ -43,7 +43,7 @@ variable "function_runtime" {
 
 variable "function_env_vars" {
   description = "Which env vars (if any) to invoke the Lambda with"
-  type        = "map"
+  type        = map(string)
 
   default = {
     # This effectively useless, but an empty map can't be used in the "aws_lambda_function" resource
@@ -74,7 +74,7 @@ variable "api_gateway_cloudwatch_metrics" {
 
 variable "tags" {
   description = "AWS Tags to add to all resources created (where possible); see https://aws.amazon.com/answers/account-management/aws-tagging-strategies/"
-  type        = "map"
+  type        = map(string)
   default     = {}
 }
 

--- a/aws/aws_lambda_cronjob/variables.tf
+++ b/aws/aws_lambda_cronjob/variables.tf
@@ -48,7 +48,7 @@ variable "function_runtime" {
 
 variable "function_env_vars" {
   description = "Which env vars (if any) to invoke the Lambda with"
-  type        = "map"
+  type        = map(string)
 
   default = {
     # This effectively useless, but an empty map can't be used in the "aws_lambda_function" resource
@@ -64,7 +64,7 @@ variable "lambda_logging_enabled" {
 
 variable "tags" {
   description = "AWS Tags to add to all resources created (where possible); see https://aws.amazon.com/answers/account-management/aws-tagging-strategies/"
-  type        = "map"
+  type        = map(string)
   default     = {}
 }
 

--- a/aws/aws_mailgun_domain/variables.tf
+++ b/aws/aws_mailgun_domain/variables.tf
@@ -18,6 +18,6 @@ variable "wildcard" {
 
 variable "tags" {
   description = "AWS Tags to add to all resources created (where possible); see https://aws.amazon.com/answers/account-management/aws-tagging-strategies/"
-  type        = "map"
+  type        = map(string)
   default     = {}
 }

--- a/aws/aws_reverse_proxy/certificate.tf
+++ b/aws/aws_reverse_proxy/certificate.tf
@@ -1,7 +1,7 @@
 # Generate a certificate for the domain automatically using ACM
 # https://www.terraform.io/docs/providers/aws/r/acm_certificate.html
 resource "aws_acm_certificate" "this" {
-  provider          = "aws.us_east_1"                                                              # because ACM is only available in the "us-east-1" region
+  provider          = aws.us_east_1                                                            # because ACM is only available in the "us-east-1" region
   domain_name       = "${var.site_domain}"
   validation_method = "DNS"                                                                        # the required records are created below
   tags              = "${merge(var.tags, map("Name", "${var.comment_prefix}${var.site_domain}"))}"
@@ -18,7 +18,7 @@ resource "aws_route53_record" "cert_validation" {
 
 # Request a validation for the cert with ACM
 resource "aws_acm_certificate_validation" "this" {
-  provider                = "aws.us_east_1"                                # because ACM is only available in the "us-east-1" region
+  provider                = aws.us_east_1                             # because ACM is only available in the "us-east-1" region
   certificate_arn         = "${aws_acm_certificate.this.arn}"
   validation_record_fqdns = ["${aws_route53_record.cert_validation.fqdn}"]
 }

--- a/aws/aws_reverse_proxy/lambda.tf
+++ b/aws/aws_reverse_proxy/lambda.tf
@@ -33,7 +33,7 @@ data "archive_file" "lambda_zip" {
 }
 
 resource "aws_lambda_function" "viewer_request" {
-  provider = "aws.us_east_1" # because: error creating CloudFront Distribution: InvalidLambdaFunctionAssociation: The function must be in region 'us-east-1'
+  provider = aws.us_east_1 # because: error creating CloudFront Distribution: InvalidLambdaFunctionAssociation: The function must be in region 'us-east-1'
 
   # lambda_zip.output_path will be absolute, i.e. different on different machines.
   # This can cause Terraform to notice differences that aren't actually there, so let's convert it to a relative one.
@@ -51,7 +51,7 @@ resource "aws_lambda_function" "viewer_request" {
 }
 
 resource "aws_lambda_function" "viewer_response" {
-  provider = "aws.us_east_1" # because: error creating CloudFront Distribution: InvalidLambdaFunctionAssociation: The function must be in region 'us-east-1'
+  provider = aws.us_east_1 # because: error creating CloudFront Distribution: InvalidLambdaFunctionAssociation: The function must be in region 'us-east-1'
 
   # lambda_zip.output_path will be absolute, i.e. different on different machines.
   # This can cause Terraform to notice differences that aren't actually there, so let's convert it to a relative one.

--- a/aws/aws_reverse_proxy/variables.tf
+++ b/aws/aws_reverse_proxy/variables.tf
@@ -38,7 +38,7 @@ variable "default_root_object" {
 
 variable "add_response_headers" {
   description = "Map of HTTP headers (if any) to add to outgoing responses before sending them to clients"
-  type        = "map"
+  type        = map(string)
 
   default = {
     "Strict-Transport-Security" = "max-age=31557600; preload" # i.e. 1 year (in seconds)
@@ -105,7 +105,7 @@ variable "lambda_logging_enabled" {
 
 variable "tags" {
   description = "AWS Tags to add to all resources created (where possible); see https://aws.amazon.com/answers/account-management/aws-tagging-strategies/"
-  type        = "map"
+  type        = map(string)
   default     = {}
 }
 

--- a/aws/aws_static_site/variables.tf
+++ b/aws/aws_static_site/variables.tf
@@ -39,7 +39,7 @@ variable "default_root_object" {
 
 variable "add_response_headers" {
   description = "Map of HTTP headers (if any) to add to outgoing responses before sending them to clients"
-  type        = "map"
+  type        = map(string)
 
   default = {
     "Strict-Transport-Security" = "max-age=31557600; preload" # i.e. 1 year (in seconds)
@@ -73,7 +73,7 @@ variable "lambda_logging_enabled" {
 
 variable "tags" {
   description = "AWS Tags to add to all resources created (where possible); see https://aws.amazon.com/answers/account-management/aws-tagging-strategies/"
-  type        = "map"
+  type        = map(string)
   default     = {}
 }
 

--- a/aws/static_website_ssl_cloudfront_private_s3/main.tf
+++ b/aws/static_website_ssl_cloudfront_private_s3/main.tf
@@ -11,7 +11,7 @@ module "acm" {
   tags        = var.tags
 
   providers = {
-    aws = "aws.us_east_1" # cloudfront needs acm certificate to be from "us-east-1" region
+    aws = aws.us_east_1 # cloudfront needs acm certificate to be from "us-east-1" region
   }
 }
 

--- a/aws/static_website_ssl_cloudfront_private_s3/variables.tf
+++ b/aws/static_website_ssl_cloudfront_private_s3/variables.tf
@@ -4,7 +4,7 @@ variable "region" {
 
 variable "tags" {
   description = "AWS Tags to add to all resources created (where possible); see https://aws.amazon.com/answers/account-management/aws-tagging-strategies/"
-  type        = "map"
+  type        = map(string)
   default     = {}
 }
 


### PR DESCRIPTION
This PR updates deprecated Terraform 0.11 syntax used in multiple AWS examples.

### Changes made:
- Updated `type = "map"` to `type = map(string)` across AWS modules.
- Updated quoted provider reference `"aws.us_east_1"` to `aws.us_east_1`.
- Cleaned and modernized variable blocks to follow Terraform 0.12+ standards.

### Verified:
- Syntax validation using Terraform v0.15.3 (quoted type constraint errors resolved).

Closes #29 
