### PR TITLE
Replace deprecated map() with HCL2 map literals in aws_vpc_msk

### DIFF
--- a/aws/aws_vpc_msk/msk-client.tf
+++ b/aws/aws_vpc_msk/msk-client.tf
@@ -54,9 +54,9 @@ resource "aws_instance" "Kafka-Client-EC2-Instance" {
 
   tags = merge(
     local.common-tags,
-    map(
-      "Name", "Kafka-Client-EC2-Instance"
-    )
+    {
+      "Name" = "Kafka-Client-EC2-Instance"
+    }
   )
 }
 

--- a/aws/aws_vpc_msk/msk-cluster.tf
+++ b/aws/aws_vpc_msk/msk-cluster.tf
@@ -3,8 +3,8 @@ resource "aws_cloudwatch_log_group" "cloudwatch_log_group" {
 }
 
 resource "aws_msk_configuration" "msk_cluster_config" {
-  kafka_versions = [var.msk_cluster_version]
-  name           = "msk-${lower(var.environment)}-cluster-cfg-${random_uuid.randuuid.result}"
+  kafka_versions    = [var.msk_cluster_version]
+  name              = "msk-${lower(var.environment)}-cluster-cfg-${random_uuid.randuuid.result}"
   server_properties = <<PROPERTIES
 auto.create.topics.enable = true
 delete.topic.enable = true
@@ -36,10 +36,10 @@ resource "aws_msk_cluster" "msk_cluster" {
   }
 */
 
-configuration_info {
-  arn = aws_msk_configuration.msk_cluster_config.arn
-  revision = 1
-}
+  configuration_info {
+    arn      = aws_msk_configuration.msk_cluster_config.arn
+    revision = 1
+  }
   encryption_info {
     encryption_in_transit {
       client_broker = var.encryption_type
@@ -59,9 +59,9 @@ configuration_info {
 
   tags = merge(
     local.common-tags,
-    map(
-      "Name", "msk-${lower(var.environment)}-cluster"
-    )
+    {
+      "Name" = "msk-${lower(var.environment)}-cluster"
+    }
   )
 }
 

--- a/aws/aws_vpc_msk/network-routing.tf
+++ b/aws/aws_vpc_msk/network-routing.tf
@@ -3,10 +3,10 @@ resource "aws_internet_gateway" "main-igw" {
   vpc_id = aws_vpc.msk_vpc.id
   tags = merge(
     local.common-tags,
-    map(
-      "Name", "MSK-IGW",
-      "Description", "Internet Gateway"
-    )
+    {
+      "Name"        = "MSK-IGW"
+      "Description" = "Internet Gateway"
+    }
   )
 }
 
@@ -19,10 +19,10 @@ resource "aws_nat_gateway" "main-natgw" {
   subnet_id     = aws_subnet.public_subnet[0].id
   tags = merge(
     local.common-tags,
-    map(
-      "Name", "MSK-NatGateway",
-      "Description", "NAT Gateway"
-    )
+    {
+      "Name"        = "MSK-NatGateway"
+      "Description" = "NAT Gateway"
+    }
   )
 }
 
@@ -37,10 +37,10 @@ resource "aws_route_table" "PublicRouteTable" {
   }
   tags = merge(
     local.common-tags,
-    map(
-      "Name", "MSK-Public-Routetable",
-      "Description", "Public-Routetable"
-    )
+    {
+      "Name"        = "MSK-Public-Routetable"
+      "Description" = "Public-Routetable"
+    }
   )
 
 }
@@ -53,10 +53,10 @@ resource "aws_route_table" "PrivateRouteTable" {
   }
   tags = merge(
     local.common-tags,
-    map(
-      "Name", "MSK-Private-Routetable",
-      "Description", "Private-Routetable"
-    )
+    {
+      "Name"        = "MSK-Private-Routetable"
+      "Description" = "Private-Routetable"
+    }
   )
 }
 

--- a/aws/aws_vpc_msk/security_group.tf
+++ b/aws/aws_vpc_msk/security_group.tf
@@ -33,9 +33,9 @@ resource "aws_security_group" "KafkaClusterSG" {
 
   tags = merge(
     local.common-tags,
-    map(
-      "Name", "msk-${lower(var.environment)}-sg-${random_uuid.randuuid.result}"
-    )
+    {
+      "Name" = "msk-${lower(var.environment)}-sg-${random_uuid.randuuid.result}"
+    }
   )
 }
 
@@ -61,8 +61,8 @@ resource "aws_security_group" "KafkaClientInstanceSG" {
 
   tags = merge(
     local.common-tags,
-    map(
-      "Name", "KafkaClientInstanceSG"
-    )
+    {
+      "Name" = "KafkaClientInstanceSG"
+    }
   )
 }

--- a/aws/aws_vpc_msk/subnets.tf
+++ b/aws/aws_vpc_msk/subnets.tf
@@ -8,10 +8,10 @@ resource "aws_subnet" "private_subnet" {
 
   tags = merge(
     local.common-tags,
-    map(
-      "Name", "MSK-${lower(var.environment)}-private-subnet-${count.index + 1}",
-      "Description", "${lower(var.environment)} private subnet - ${count.index + 1}"
-    )
+    {
+      "Name"        = "MSK-${lower(var.environment)}-private-subnet-${count.index + 1}"
+      "Description" = "${lower(var.environment)} private subnet - ${count.index + 1}"
+    }
   )
 
 }
@@ -26,10 +26,10 @@ resource "aws_subnet" "public_subnet" {
 
   tags = merge(
     local.common-tags,
-    map(
-      "Name", "msk-${lower(var.environment)}-public-subnet-${count.index + 1}",
-      "Description", "${lower(var.environment)} private subnet - ${count.index + 1}"
-    )
+    {
+      "Name"        = "msk-${lower(var.environment)}-public-subnet-${count.index + 1}"
+      "Description" = "${lower(var.environment)} private subnet - ${count.index + 1}"
+    }
   )
 
 }

--- a/aws/aws_vpc_msk/variables.tf
+++ b/aws/aws_vpc_msk/variables.tf
@@ -29,11 +29,11 @@ variable "vpc_cidr" {
 
 variable "private_subnet_cidrs" {
   description = "Private subnet  - CIDR"
-  type        = list
+  type        = list(any)
 }
 variable "public_subnet_cidrs" {
   description = "Private subnet  - CIDR"
-  type        = list
+  type        = list(any)
 }
 
 # MSK Cluster

--- a/aws/aws_vpc_msk/vpc.tf
+++ b/aws/aws_vpc_msk/vpc.tf
@@ -2,9 +2,9 @@ resource "aws_vpc" "msk_vpc" {
   cidr_block = var.vpc_cidr
   tags = merge(
     local.common-tags,
-    map(
-      "Name", "msk-${lower(var.environment)}-vpc",
-      "Description", "VPC for creating MSK resources",
-    )
+    {
+      "Name"        = "msk-${lower(var.environment)}-vpc"
+      "Description" = "VPC for creating MSK resources"
+    }
   )
 }


### PR DESCRIPTION
## Terraform Audit Report

### Checks Run

| Check | Status | Details |
|-------|--------|---------|
| terraform fmt | FAIL | 63 files not formatted across all modules |
| terraform validate | FAIL | Multiple root modules fail validation (see findings) |
| tflint | SKIPPED | Not installed |
| tfsec/trivy | SKIPPED | Not installed |
| terraform plan | SKIPPED | No cloud credentials available |

### Findings

#### P0 — Bugs & Breakage
- [x] `aws/aws_vpc_msk/*.tf` — Deprecated `map()` function causes validate failure (7 files affected)
- [ ] `aws/aws_vpc_msk/msk-cluster.tf:22` — `ebs_volume_size` is no longer a direct argument in `broker_node_group_info` for current AWS provider
- [ ] `aws/static_website_ssl_cloudfront_private_s3/variables.tf:7` — Quoted type `"map"` causes validate failure; should be `map(string)`
- [ ] `azure/layers/main.tf:29` — `address_prefix` removed in current azurerm provider; should be `address_prefixes`
- [ ] `google_cloud/camunda-secure/camunda.tf:8` — `google_project_iam_member` missing required `project` argument
- [ ] `google_cloud/camunda/camunda.tf:25` — `google_project_iam_member` missing required `project` argument
- [ ] `google_cloud/oathkeeper/main.tf:49` — `bucket_policy_only` deprecated; should be `uniform_bucket_level_access`
- [ ] `google_cloud/CQRS_bigquery_memorystore` — Quoted type `"string"` in vendored module causes validate failure

#### P1 — Security
- [ ] `aws/aws_ec2_ebs_docker_host/security.tf:22` — SSH (port 22) open to `0.0.0.0/0`
- [ ] `aws/aws_ec2_ebs_docker_host/outputs.tf:36` — `ssh_private_key` output exposes private key content without `sensitive = true`
- [ ] `aws/wordpress_fargate/variables.tf:73-76` — `db_master_username` and `db_master_password` variables not marked `sensitive = true`
- [ ] `aws/aws_reverse_proxy/variables.tf:62-66` — `basic_auth_username` and `basic_auth_password` not marked `sensitive = true`
- [ ] `aws/aws_mailgun_domain/variables.tf:6` — `smtp_password` variable not marked `sensitive = true`
- [ ] `aws/aws_static_site/variables.tf:42-46` — `basic_auth_username` and `basic_auth_password` not marked `sensitive = true`
- [ ] `aws/wordpress_fargate/db.tf` — RDS cluster has no `storage_encrypted = true`
- [ ] `aws/aws_vpc_msk/kms.tf` — KMS key policies use `"Action": "kms:*"` (overly permissive)
- [ ] `aws/aws_ec2_ebs_docker_host/variables.tf:37` — Hardcoded AMI ID `ami-0bdf93799014acdc4`

#### P2 — Structural & Patterns
- [ ] `aws/aws_vpc_msk/msk-cluster.tf:16` — Uses `count = length(var.private_subnet_cidrs)` to create MSK clusters; likely should be a single cluster
- [ ] `aws/aws_vpc_msk/variables.tf:33-37` — `private_subnet_cidrs` and `public_subnet_cidrs` declared as untyped `list` instead of `list(string)`
- [ ] `aws/wordpress_fargate/variables.tf:3` — `tags` variable uses untyped `map` instead of `map(string)`
- [ ] Multiple modules use `type = "map"` (quoted legacy syntax): `aws_lambda_api`, `aws_lambda_cronjob`, `aws_reverse_proxy`, `aws_static_site`, `aws_domain_redirect`, `aws_mailgun_domain`, `aws_ec2_ebs_docker_host`, `generic/docker_compose_host`
- [ ] `aws/aws_lambda_api/variables.tf:42` — `function_runtime` defaults to `nodejs8.10` (EOL runtime)
- [ ] `aws/aws_lambda_cronjob/variables.tf:42` — `function_runtime` defaults to `nodejs8.10` (EOL runtime)
- [ ] `aws/aws_reverse_proxy/lambda.tf:48,66` — Lambda runtime hardcoded to `nodejs8.10` (EOL)
- [ ] `aws/wordpress_fargate/db.tf` — RDS cluster missing `lifecycle { prevent_destroy = true }`
- [ ] `aws/wordpress_fargate/efs.tf` — EFS file system missing `lifecycle { prevent_destroy = true }`
- [ ] `aws/wordpress_fargate/efs.tf` — EFS not encrypted at rest
- [ ] Multiple provider blocks use deprecated in-block `version` constraints instead of `required_providers`

#### P3 — Style & Consistency
- [ ] 63 files fail `terraform fmt` across all modules
- [ ] `aws/aws_vpc_msk` — Mixed naming: PascalCase (`KafkaClusterSG`, `PublicRouteTable`) and kebab-case resource names
- [ ] `aws/aws_vpc_msk/variables.tf:8` — Variable uses kebab-case (`aws-profile`) instead of snake_case
- [ ] No module directories have `README.md` files
- [ ] `aws/aws_vpc_msk/common-tags-data.tf:3-4` — Unnecessary nested interpolation
- [ ] Inconsistent tag key casing across modules
- [ ] `aws/wordpress_fargate/output.tf` — Empty output file

### Fix Applied

**Issue**: Deprecated `map()` function calls in `aws/aws_vpc_msk` cause `terraform validate` to fail  
**Priority**: P0  
**Files changed**: `aws/aws_vpc_msk/vpc.tf`, `aws/aws_vpc_msk/security_group.tf`, `aws/aws_vpc_msk/subnets.tf`, `aws/aws_vpc_msk/msk-cluster.tf`, `aws/aws_vpc_msk/msk-client.tf`, `aws/aws_vpc_msk/network-routing.tf`, `aws/aws_vpc_msk/variables.tf`  
**Why this one**: Highest-impact P0 — affects 7 files in a single root module, straightforward to fix without changing module interfaces, and the `map()` function removal is a hard error (not just a warning).

### Remaining Issues

30 issues remain across P0-P3. Run this automation again to fix the next one.
