### PR TITLE
Auto-Refactor: Replace deprecated map() with HCL2 map literals in aws_vpc_msk

### DIFF
--- a/aws/aws_vpc_msk/msk-client.tf
+++ b/aws/aws_vpc_msk/msk-client.tf
@@ -54,9 +54,9 @@ resource "aws_instance" "Kafka-Client-EC2-Instance" {
 
   tags = merge(
     local.common-tags,
-    map(
-      "Name", "Kafka-Client-EC2-Instance"
-    )
+    {
+      "Name" = "Kafka-Client-EC2-Instance"
+    }
   )
 }
 

--- a/aws/aws_vpc_msk/msk-cluster.tf
+++ b/aws/aws_vpc_msk/msk-cluster.tf
@@ -3,8 +3,8 @@ resource "aws_cloudwatch_log_group" "cloudwatch_log_group" {
 }
 
 resource "aws_msk_configuration" "msk_cluster_config" {
-  kafka_versions = [var.msk_cluster_version]
-  name           = "msk-${lower(var.environment)}-cluster-cfg-${random_uuid.randuuid.result}"
+  kafka_versions    = [var.msk_cluster_version]
+  name              = "msk-${lower(var.environment)}-cluster-cfg-${random_uuid.randuuid.result}"
   server_properties = <<PROPERTIES
 auto.create.topics.enable = true
 delete.topic.enable = true
@@ -36,10 +36,10 @@ resource "aws_msk_cluster" "msk_cluster" {
   }
 */
 
-configuration_info {
-  arn = aws_msk_configuration.msk_cluster_config.arn
-  revision = 1
-}
+  configuration_info {
+    arn      = aws_msk_configuration.msk_cluster_config.arn
+    revision = 1
+  }
   encryption_info {
     encryption_in_transit {
       client_broker = var.encryption_type
@@ -59,9 +59,9 @@ configuration_info {
 
   tags = merge(
     local.common-tags,
-    map(
-      "Name", "msk-${lower(var.environment)}-cluster"
-    )
+    {
+      "Name" = "msk-${lower(var.environment)}-cluster"
+    }
   )
 }
 

--- a/aws/aws_vpc_msk/network-routing.tf
+++ b/aws/aws_vpc_msk/network-routing.tf
@@ -3,10 +3,10 @@ resource "aws_internet_gateway" "main-igw" {
   vpc_id = aws_vpc.msk_vpc.id
   tags = merge(
     local.common-tags,
-    map(
-      "Name", "MSK-IGW",
-      "Description", "Internet Gateway"
-    )
+    {
+      "Name"        = "MSK-IGW"
+      "Description" = "Internet Gateway"
+    }
   )
 }
 
@@ -19,10 +19,10 @@ resource "aws_nat_gateway" "main-natgw" {
   subnet_id     = aws_subnet.public_subnet[0].id
   tags = merge(
     local.common-tags,
-    map(
-      "Name", "MSK-NatGateway",
-      "Description", "NAT Gateway"
-    )
+    {
+      "Name"        = "MSK-NatGateway"
+      "Description" = "NAT Gateway"
+    }
   )
 }
 
@@ -37,10 +37,10 @@ resource "aws_route_table" "PublicRouteTable" {
   }
   tags = merge(
     local.common-tags,
-    map(
-      "Name", "MSK-Public-Routetable",
-      "Description", "Public-Routetable"
-    )
+    {
+      "Name"        = "MSK-Public-Routetable"
+      "Description" = "Public-Routetable"
+    }
   )
 
 }
@@ -53,10 +53,10 @@ resource "aws_route_table" "PrivateRouteTable" {
   }
   tags = merge(
     local.common-tags,
-    map(
-      "Name", "MSK-Private-Routetable",
-      "Description", "Private-Routetable"
-    )
+    {
+      "Name"        = "MSK-Private-Routetable"
+      "Description" = "Private-Routetable"
+    }
   )
 }
 

--- a/aws/aws_vpc_msk/security_group.tf
+++ b/aws/aws_vpc_msk/security_group.tf
@@ -33,9 +33,9 @@ resource "aws_security_group" "KafkaClusterSG" {
 
   tags = merge(
     local.common-tags,
-    map(
-      "Name", "msk-${lower(var.environment)}-sg-${random_uuid.randuuid.result}"
-    )
+    {
+      "Name" = "msk-${lower(var.environment)}-sg-${random_uuid.randuuid.result}"
+    }
   )
 }
 
@@ -61,8 +61,8 @@ resource "aws_security_group" "KafkaClientInstanceSG" {
 
   tags = merge(
     local.common-tags,
-    map(
-      "Name", "KafkaClientInstanceSG"
-    )
+    {
+      "Name" = "KafkaClientInstanceSG"
+    }
   )
 }

--- a/aws/aws_vpc_msk/subnets.tf
+++ b/aws/aws_vpc_msk/subnets.tf
@@ -8,10 +8,10 @@ resource "aws_subnet" "private_subnet" {
 
   tags = merge(
     local.common-tags,
-    map(
-      "Name", "MSK-${lower(var.environment)}-private-subnet-${count.index + 1}",
-      "Description", "${lower(var.environment)} private subnet - ${count.index + 1}"
-    )
+    {
+      "Name"        = "MSK-${lower(var.environment)}-private-subnet-${count.index + 1}"
+      "Description" = "${lower(var.environment)} private subnet - ${count.index + 1}"
+    }
   )
 
 }
@@ -26,10 +26,10 @@ resource "aws_subnet" "public_subnet" {
 
   tags = merge(
     local.common-tags,
-    map(
-      "Name", "msk-${lower(var.environment)}-public-subnet-${count.index + 1}",
-      "Description", "${lower(var.environment)} private subnet - ${count.index + 1}"
-    )
+    {
+      "Name"        = "msk-${lower(var.environment)}-public-subnet-${count.index + 1}"
+      "Description" = "${lower(var.environment)} private subnet - ${count.index + 1}"
+    }
   )
 
 }

--- a/aws/aws_vpc_msk/variables.tf
+++ b/aws/aws_vpc_msk/variables.tf
@@ -29,11 +29,11 @@ variable "vpc_cidr" {
 
 variable "private_subnet_cidrs" {
   description = "Private subnet  - CIDR"
-  type        = list
+  type        = list(any)
 }
 variable "public_subnet_cidrs" {
   description = "Private subnet  - CIDR"
-  type        = list
+  type        = list(any)
 }
 
 # MSK Cluster

--- a/aws/aws_vpc_msk/vpc.tf
+++ b/aws/aws_vpc_msk/vpc.tf
@@ -2,9 +2,9 @@ resource "aws_vpc" "msk_vpc" {
   cidr_block = var.vpc_cidr
   tags = merge(
     local.common-tags,
-    map(
-      "Name", "msk-${lower(var.environment)}-vpc",
-      "Description", "VPC for creating MSK resources",
-    )
+    {
+      "Name"        = "msk-${lower(var.environment)}-vpc"
+      "Description" = "VPC for creating MSK resources"
+    }
   )
 }


### PR DESCRIPTION
## Summary

The `map()` function was deprecated in Terraform v0.12 and fully removed in later versions. All 11 usages across 7 files in `aws/aws_vpc_msk/` cause `terraform validate` to fail with:

```
Call to function "map" failed: the "map" function was deprecated in Terraform v0.12
and is no longer available; use tomap({ ... }) syntax to write a literal map.
```

This PR replaces every `map("key", "value", ...)` call with native HCL2 `{ "key" = "value" }` syntax.

## Changes

- **`vpc.tf`** — VPC resource tags
- **`security_group.tf`** — `KafkaClusterSG` and `KafkaClientInstanceSG` tags
- **`subnets.tf`** — Private and public subnet tags
- **`msk-cluster.tf`** — MSK cluster tags (also picks up `terraform fmt` fixes for indentation)
- **`msk-client.tf`** — EC2 Kafka client instance tags
- **`network-routing.tf`** — IGW, NAT gateway, and route table tags
- **`variables.tf`** — `terraform fmt` alignment only (no logic changes)

## Validation

After the fix, `terraform validate` no longer reports any `map()` errors for this module. One pre-existing error remains (`ebs_volume_size` argument moved to a nested block in newer AWS provider versions) — that is a separate issue unrelated to this change.